### PR TITLE
Update .rspec

### DIFF
--- a/ruby/.rspec
+++ b/ruby/.rspec
@@ -1,2 +1,2 @@
 --colour
---format nested
+--format documentation


### PR DESCRIPTION
'nested' is deprecated and 'documentation' is used instead in rspec 2.